### PR TITLE
Fix toc & footnote links

### DIFF
--- a/frontmatter/summary.tex
+++ b/frontmatter/summary.tex
@@ -3,8 +3,8 @@
 %This is the Summary
 %%=========================================
 \cleardoublepage
-\addcontentsline{toc}{section}{Abstract}
 \section*{Abstract}
+\addcontentsline{toc}{section}{Abstract}
 
 FaaS is a cutting-edge new service model that has developed with the current advancement of cloud computing.
 It allows software developers to deploy their applications quickly and with needed flexibility and scalability, while keeping infrastructure maintenance requirements very low.
@@ -16,8 +16,8 @@ We also present a proof-of-concept implementation of our design, which we have b
 We find that our platform can outperform Lean OpenWhisk in terms of latency and throughput in all tests but that Lean OpenWhisk has higher success rates for a low number of simultaneous clients.
 
 \newpage
-\addcontentsline{toc}{section}{Zusammenfassung}
 \section*{Zusammenfassung}
+\addcontentsline{toc}{section}{Zusammenfassung}
 
 FaaS ist ein innovatives neues Servicemodell, das sich mit dem aktuellen Vormarsch des Cloud Computing entwickelt hat.
 Softwareentwicklende können ihre Anwendungen schneller und mit der erforderlichen Flexibilität und Skalierbarkeit bereitstellen und gleichzeitig den Wartungsaufwand für die Infrastruktur sehr gering halten.

--- a/thesis.tex
+++ b/thesis.tex
@@ -15,6 +15,11 @@
 \usepackage{setspace}
 \linespread{1.5}
 \setcounter{tocdepth}{2}
+
+% Fußnote
+\usepackage[hang]{footmisc} % load before hyperref to correctly link footnote refs
+\setlength{\footnotemargin}{-0.8em}
+
 \usepackage[colorlinks=true, pdfstartview=FitV,
 linkcolor=blue, citecolor=blue, urlcolor=blue]{hyperref}
 \setlength{\parindent}{0pt} % No indentation between paragraphs
@@ -32,9 +37,6 @@ linkcolor=blue, citecolor=blue, urlcolor=blue]{hyperref}
 \usepackage{subcaption}
 \usepackage{floatpag} % to move floatpagenr to topright
 
-% Fußnote
-\usepackage[hang]{footmisc}
-\setlength{\footnotemargin}{-0.8em}
 
 \usepackage{csquotes}
 \usepackage{afterpage} % needed for empty page after front


### PR DESCRIPTION
Hi, this pull request fixes two bugs I encountered with the template:

1. Abstract and Zusammenfassung do not correctly link in the table of contents (`\addcontentsline` needs to be called after `\section`).
2. Footnote references link to the first page instead of to the right footnote on the page (https://tex.stackexchange.com/questions/71664/why-are-all-of-my-footnotes-hyperlinked-to-the-titlepage).

